### PR TITLE
Update agent configuration

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -1,5 +1,5 @@
-- name: registration.registries.ca
-  version: '1.0.40'
+- name: registration.von.canada.ca
+  version: "1.0.40"
   attributes:
     registration_id:
       description: Registration/Incorporation Number or Identifying Number
@@ -60,7 +60,7 @@
       required: false
 
 - name: address.registries.ca
-  version: '1.0.40'
+  version: "1.0.40"
   attributes:
     registration_id:
       description: Unique identifer assigned to entity by registrar
@@ -99,8 +99,8 @@
       description: Reason for credential issue/update
       required: false
 
-- name: relationship.registries.ca
-  version: '1.0.40'
+- name: relationship.von.canada.ca
+  version: "1.0.40"
   attributes:
     registration_id:
       description: Unique identifer assigned to entity by registrar

--- a/config/services.yml
+++ b/config/services.yml
@@ -30,7 +30,7 @@ issuers:
 
     credential_types:
       - description: Registration
-        schema: registration.registries.ca
+        schema: registration.von.canada.ca
         issuer_url: $APPLICATION_URL_REGISTRATION
         credential:
           effective_date:
@@ -233,7 +233,7 @@ issuers:
                 from: claim
 
       - description: Relationship
-        schema: relationship.registries.ca
+        schema: relationship.von.canada.ca
         issuer_url: $APPLICATION_URL_RELATIONSHIP
         credential:
           effective_date:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,4 +5,4 @@ default:
   TEMPLATE_PATH: ../templates
   TOB_API_URL: http://tob-api:8080/api/v2
   TOB_APP_URL: http://localhost:8080
-  INDY_WALLET_SEED: gccorp.von.canada.ca_dev_00000000
+  INDY_WALLET_SEED: gccorp.von.canada.ca_dev_0000000


### PR DESCRIPTION
Applied fixes:
- seed value was longer than required, it must be 32 characters
- schemas were not named consistently across the configuration files